### PR TITLE
Implement bcrypt for auth

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -15,6 +15,7 @@ func (app *application) routes() http.Handler {
 	mux := pat.New()
 
 	mux.Post("/companies/register", standardMiddleware.ThenFunc(app.companyHandler.Register))
+	mux.Post("/companies/login", standardMiddleware.ThenFunc(app.companyHandler.Login))
 	mux.Get("/companies", standardMiddleware.ThenFunc(app.companyHandler.GetAll))
 	mux.Get("/companies/id/:id", standardMiddleware.ThenFunc(app.companyHandler.GetByID))
 	mux.Get("/companies/phone/:phone", standardMiddleware.ThenFunc(app.companyHandler.GetByPhone))

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,9 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/google/uuid v1.6.0
 	github.com/justinas/alice v1.2.0
-	github.com/rs/cors v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+        github.com/rs/cors v1.11.1
+       golang.org/x/crypto v0.17.0
+        gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/internal/handlers/company_handler.go
+++ b/internal/handlers/company_handler.go
@@ -33,6 +33,27 @@ func (h *CompanyHandler) Register(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
+// POST /companies/login
+func (h *CompanyHandler) Login(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Phone    string `json:"phone"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil || input.Phone == "" || input.Password == "" {
+		http.Error(w, "invalid input", http.StatusBadRequest)
+		return
+	}
+
+	company, err := h.Service.Login(input.Phone, input.Password)
+	if err != nil {
+		http.Error(w, "authentication failed", http.StatusUnauthorized)
+		return
+	}
+
+	company.Password = ""
+	json.NewEncoder(w).Encode(company)
+}
+
 // GET /companies
 func (h *CompanyHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 	companies, err := h.Service.List()

--- a/internal/repositories/company_repo.go
+++ b/internal/repositories/company_repo.go
@@ -70,3 +70,14 @@ func (r *CompanyRepository) Delete(id int) error {
 	_, err := r.DB.Exec(`DELETE FROM companies WHERE id = ?`, id)
 	return err
 }
+
+func (r *CompanyRepository) Authenticate(phone string) (*models.Company, error) {
+	query := `SELECT id, name, email, phone, password FROM companies WHERE phone = ?`
+	row := r.DB.QueryRow(query, phone)
+	var c models.Company
+	err := row.Scan(&c.ID, &c.Name, &c.Email, &c.Phone, &c.Password)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}


### PR DESCRIPTION
## Summary
- hash passwords when registering companies
- verify hashed password during login using bcrypt
- add bcrypt dependency

## Testing
- `gofmt -w internal/services/company_service.go internal/repositories/company_repo.go`
- `go mod tidy` *(fails: `Forbidden` errors)*

------
https://chatgpt.com/codex/tasks/task_e_68413d5643148324b87724ec3ba45954