### PR TITLE
Handle PDF uploads as form-data

### DIFF
--- a/internal/handlers/contract_handler.go
+++ b/internal/handlers/contract_handler.go
@@ -6,13 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
-	"github.com/jung-kurt/gofpdf"
-	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 )
 
 type ContractHandler struct {
@@ -24,56 +22,57 @@ func NewContractHandler(service *services.ContractService) *ContractHandler {
 }
 
 func (h *ContractHandler) Create(w http.ResponseWriter, r *http.Request) {
-	var input models.Contract
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		http.Error(w, "invalid input", http.StatusBadRequest)
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
 		return
 	}
-	input.ContractToken = uuid.New().String()
 
-	// 1. Сохраняем контракт в базе (input.ID заполняется после Create)
-	err := h.Service.Create(&input)
-	if err != nil {
+	companyID, _ := strconv.Atoi(r.FormValue("company_id"))
+	templateID, _ := strconv.Atoi(r.FormValue("template_id"))
+	method := r.FormValue("method")
+	clientFilled := r.FormValue("client_filled") == "true"
+
+	input := models.Contract{
+		CompanyID:     companyID,
+		TemplateID:    templateID,
+		ClientFilled:  clientFilled,
+		Method:        method,
+		ContractToken: uuid.New().String(),
+	}
+
+	if err := h.Service.Create(&input); err != nil {
 		http.Error(w, "failed to create contract", http.StatusInternalServerError)
 		return
 	}
 
-	// 2. Создаём директорию для компании
 	contractsDir := fmt.Sprintf("uploads/contracts/company_%d", input.CompanyID)
 	if err := os.MkdirAll(contractsDir, 0755); err != nil {
 		http.Error(w, "cannot create directory", http.StatusInternalServerError)
 		return
 	}
 
-	// 3. Пути к файлам
-	mainPDF := input.GeneratedPDFPath // исходный PDF с ватермаркой
-	certPDF := filepath.Join(contractsDir, fmt.Sprintf("cert_%d.pdf", input.ID))
 	finalPDF := filepath.Join(contractsDir, fmt.Sprintf("final_%d.pdf", input.ID))
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "file required", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
 
-	// 4. Имя компании (можешь получить из базы)
-	companyName := "Test Company"
-
-	// 5. Генерим страницу сертификата
-	if err := GenerateCertificatePDF(certPDF, companyName, time.Now()); err != nil {
-		http.Error(w, "certificate page error: "+err.Error(), http.StatusInternalServerError)
+	out, err := os.Create(finalPDF)
+	if err != nil {
+		http.Error(w, "cannot save file", http.StatusInternalServerError)
+		return
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, file); err != nil {
+		http.Error(w, "write failed", http.StatusInternalServerError)
 		return
 	}
 
-	// 6. Мержим основной PDF и сертификат
-	if err := api.MergeCreateFile([]string{mainPDF, certPDF}, finalPDF, false, nil); err != nil {
-		http.Error(w, "merge error: "+err.Error(), http.StatusInternalServerError)
-		_ = os.Remove(certPDF)
-		return
-	}
-
-	// 7. Удаляем временный сертификат
-	_ = os.Remove(certPDF)
-
-	// 8. Обновляем путь финального файла в контракте
 	input.GeneratedPDFPath = finalPDF
 	_ = h.Service.UpdatePDFPath(input.ID, finalPDF)
 
-	// 9. Вернём контракт с финальным путём
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(input)
 }
@@ -137,82 +136,70 @@ func (h *ContractHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *ContractHandler) CreateWithFields(w http.ResponseWriter, r *http.Request) {
-	var input models.CreateContractRequest
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		http.Error(w, "invalid input", http.StatusBadRequest)
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
 		return
 	}
 
-	contract := models.Contract{
-		CompanyID:        input.CompanyID,
-		TemplateID:       input.TemplateID,
-		GeneratedPDFPath: input.GeneratedPDFPath,
-		ClientFilled:     input.ClientFilled,
-		Method:           input.Method,
-		ContractToken:    uuid.New().String(),
+	companyID, _ := strconv.Atoi(r.FormValue("company_id"))
+	templateID, _ := strconv.Atoi(r.FormValue("template_id"))
+	method := r.FormValue("method")
+	clientFilled := r.FormValue("client_filled") == "true"
+
+	var fieldDTOs []models.ContractFieldDTO
+	if val := r.FormValue("fields"); val != "" {
+		_ = json.Unmarshal([]byte(val), &fieldDTOs)
 	}
 
-	fields := make([]models.ContractField, 0)
-	for _, f := range input.Fields {
+	contract := models.Contract{
+		CompanyID:     companyID,
+		TemplateID:    templateID,
+		ClientFilled:  clientFilled,
+		Method:        method,
+		ContractToken: uuid.New().String(),
+	}
+
+	fields := make([]models.ContractField, 0, len(fieldDTOs))
+	for _, f := range fieldDTOs {
 		fields = append(fields, models.ContractField{
 			FieldName: f.FieldName,
 			FieldType: f.FieldType,
 		})
 	}
 
-	// Создаём контракт и поля, contract.ID будет получен после сохранения
-	err := h.Service.CreateWithFields(&contract, fields)
-	if err != nil {
+	if err := h.Service.CreateWithFields(&contract, fields); err != nil {
 		http.Error(w, "failed to create contract and fields", http.StatusInternalServerError)
 		return
 	}
 
-	// --- Создаём директорию для компании
 	contractsDir := fmt.Sprintf("uploads/contracts/company_%d", contract.CompanyID)
 	if err := os.MkdirAll(contractsDir, 0755); err != nil {
 		http.Error(w, "cannot create directory", http.StatusInternalServerError)
 		return
 	}
 
-	mainPDF := contract.GeneratedPDFPath
-	certPDF := filepath.Join(contractsDir, fmt.Sprintf("cert_%d.pdf", contract.ID))
 	finalPDF := filepath.Join(contractsDir, fmt.Sprintf("final_%d.pdf", contract.ID))
-
-	companyName := "Test Company"
-
-	if err := GenerateCertificatePDF(certPDF, companyName, time.Now()); err != nil {
-		http.Error(w, "certificate page error: "+err.Error(), http.StatusInternalServerError)
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "file required", http.StatusBadRequest)
 		return
 	}
+	defer file.Close()
 
-	if err := api.MergeCreateFile([]string{mainPDF, certPDF}, finalPDF, false, nil); err != nil {
-		http.Error(w, "merge error: "+err.Error(), http.StatusInternalServerError)
-		_ = os.Remove(certPDF)
+	out, err := os.Create(finalPDF)
+	if err != nil {
+		http.Error(w, "cannot save file", http.StatusInternalServerError)
 		return
 	}
-
-	_ = os.Remove(certPDF)
+	defer out.Close()
+	if _, err := io.Copy(out, file); err != nil {
+		http.Error(w, "write failed", http.StatusInternalServerError)
+		return
+	}
 
 	contract.GeneratedPDFPath = finalPDF
 	_ = h.Service.UpdatePDFPath(contract.ID, finalPDF)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(contract)
-}
-
-func GenerateCertificatePDF(filename, companyName string, signedAt time.Time) error {
-	pdf := gofpdf.New("P", "mm", "A4", "")
-	pdf.AddUTF8Font("DejaVu", "", "DejaVuSans.ttf")
-	pdf.SetFont("DejaVu", "", 20)
-	pdf.AddPage()
-	pdf.CellFormat(0, 20, "Сертификат онлайн подписания", "", 1, "C", false, 0, "")
-	pdf.Ln(10)
-	pdf.SetFont("DejaVu", "", 14)
-	pdf.SetXY(10, 40)
-	pdf.MultiCell(0, 10, fmt.Sprintf(
-		"Сторона 1\nИсполнитель: %s\nПодписан: %s",
-		companyName,
-		signedAt.Format("2006-01-02 15:04:05"),
-	), "", "L", false)
-	return pdf.OutputFileAndClose(filename)
 }


### PR DESCRIPTION
## Summary
- update contract and signature handlers to read PDF files from multipart form requests
- remove server-side PDF generation logic

## Testing
- `go test ./...` *(fails: fetching modules disallowed)*

------
https://chatgpt.com/codex/tasks/task_e_685155cc491c8324a0194a0b985cbfdc