### PR TITLE
Add Mobizon SMS endpoint

### DIFF
--- a/cmd/web/initializer.go
+++ b/cmd/web/initializer.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"log"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -25,6 +26,7 @@ type application struct {
 	companyBalanceHandler      *handlers.CompanyBalanceHandler
 	tariffPlanHandler          *handlers.TariffPlanHandler
 	paymentHandler             *handlers.PaymentRequestHandler
+	smsHandler                 *handlers.SMSHandler
 }
 
 func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
@@ -73,6 +75,9 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	paymentService := service.NewPaymentRequestService(paymentRepo, tariffPlanRepo)
 	paymentHandler := handlers.NewPaymentRequestHandler(paymentService)
 
+	smsService := service.NewSMSService(os.Getenv("MOBIZON_API_KEY"))
+	smsHandler := handlers.NewSMSHandler(smsService)
+
 	return &application{
 		errorLog:                   errorLog,
 		infoLog:                    infoLog,
@@ -86,6 +91,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		companyBalanceHandler:      companyBalanceHandler,
 		tariffPlanHandler:          tariffPlanHandler,
 		paymentHandler:             paymentHandler,
+		smsHandler:                 smsHandler,
 	}
 }
 

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -73,5 +73,7 @@ func (app *application) routes() http.Handler {
 	mux.Put("/payment_requests/:id", standardMiddleware.ThenFunc(app.paymentHandler.Update))
 	mux.Del("/payment_requests/:id", standardMiddleware.ThenFunc(app.paymentHandler.Delete))
 
+	mux.Post("/sms/send", standardMiddleware.ThenFunc(app.smsHandler.Send))
+
 	return standardMiddleware.Then(mux)
 }

--- a/internal/handlers/sms_handler.go
+++ b/internal/handlers/sms_handler.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	"OzgeContract/internal/services"
+	"encoding/json"
+	"net/http"
+)
+
+// SMSHandler handles HTTP requests for sending SMS messages.
+type SMSHandler struct {
+	Service *services.SMSService
+}
+
+// NewSMSHandler creates a new SMSHandler.
+func NewSMSHandler(service *services.SMSService) *SMSHandler {
+	return &SMSHandler{Service: service}
+}
+
+// Send handles POST /sms/send requests.
+func (h *SMSHandler) Send(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Phone string `json:"phone"`
+		Text  string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Phone == "" || req.Text == "" {
+		http.Error(w, "invalid input", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.SendSMS(req.Phone, req.Text); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/internal/services/sms_service.go
+++ b/internal/services/sms_service.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// SMSService provides methods to send SMS messages via Mobizon API.
+type SMSService struct {
+	APIKey string
+}
+
+// NewSMSService creates a new SMSService with the provided API key.
+func NewSMSService(apiKey string) *SMSService {
+	return &SMSService{APIKey: apiKey}
+}
+
+// SendSMS sends an SMS message using Mobizon service.
+func (s *SMSService) SendSMS(phone, text string) error {
+	if s.APIKey == "" {
+		return fmt.Errorf("mobizon api key not configured")
+	}
+	endpoint := "https://api.mobizon.kz/service/message/sendsmsmessage"
+	values := url.Values{}
+	values.Set("apiKey", s.APIKey)
+	values.Set("recipient", phone)
+	values.Set("text", text)
+
+	resp, err := http.PostForm(endpoint, values)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("mobizon status: %s", resp.Status)
+	}
+	var result struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
+		if result.Code != 0 {
+			return fmt.Errorf("mobizon error: %s", result.Message)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- support SMS sending via Mobizon
- expose `/sms/send` endpoint

## Testing
- `go test ./...` *(fails: Forbidden while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68568f9677fc8324baeb3105092491af