### PR TITLE
Add endpoint for contract PDFs

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -35,6 +35,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/contracts/token/:token", standardMiddleware.ThenFunc(app.contractHandler.GetByToken))
 	mux.Get("/contracts/token/:token/details", standardMiddleware.ThenFunc(app.contractHandler.GetByTokenWithFields))
 	mux.Get("/contracts/company/:id", standardMiddleware.ThenFunc(app.contractHandler.GetByCompany))
+	mux.Get("/contracts/pdf/:id", standardMiddleware.ThenFunc(app.contractHandler.ServePDFByID))
 	mux.Put("/contracts/:id", standardMiddleware.ThenFunc(app.contractHandler.Update))
 	mux.Del("/contracts/:id", standardMiddleware.ThenFunc(app.contractHandler.Delete))
 


### PR DESCRIPTION
## Summary
- allow contracts to be served as PDFs
- wire the new handler in routes

## Testing
- `go test ./...` *(fails: GOPROXY blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856bce6f58483249aca528a1ba89b1e