### PR TITLE
Add compose-based Docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+MYSQL_ROOT_PASSWORD=example
+MYSQL_DATABASE=ozgecontract
+MYSQL_USER=crmuser
+MYSQL_PASSWORD=crmpass
+APP_PORT=4000
+DSN=crmuser:crmpass@tcp(db:3306)/ozgecontract?parseTime=true
+DATABASE_URL=crmuser:crmpass@tcp(db:3306)/ozgecontract?parseTime=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.24-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o app ./cmd/web/main.go
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /app/app ./app
+COPY --from=build /app/config ./config
+COPY --from=build /app/static ./static
+COPY --from=build /app/migrations ./migrations
+COPY --from=build /app/DejaVuSans.ttf ./DejaVuSans.ttf
+ENV GIN_MODE=release
+EXPOSE 4000
+CMD ["./app"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ clean_mobile_app/
 - **Go 1.23**: Latest version of Go with performance improvements.
 - **Scalability**: Designed to handle complex business logic with ease.
 - **Config Management**: Centralized and manageable application settings.
-- **Database Migrations**: Organized schema changes under the `db/migrations/` directory.
+- **Database Migrations**: Organized schema changes under the `migrations/` directory.
 
 ---
 
@@ -80,12 +80,24 @@ The configuration file (`config/config.yaml`) includes parameters like database 
 
 ## 🗃️ Database Migrations
 
-Use a tool like [golang-migrate](https://github.com/golang-migrate/migrate) to manage your database migrations. Place your `.sql` files in the `db/migrations/` folder.
+Use a tool like [golang-migrate](https://github.com/golang-migrate/migrate) to manage your database migrations. Place your `.sql` files in the `migrations/` folder.
 
 To run migrations:
 ```bash
-migrate -path db/migrations -database "your-database-url" up
+migrate -path migrations -database "your-database-url" up
 ```
+
+---
+
+## 🐳 Docker Deployment
+
+1. Create a `.env` file with your database credentials (see the provided example).
+2. Build and start all services with `docker-compose` which will run migrations using a dedicated container:
+   ```bash
+   docker-compose up --build
+   ```
+3. The application will be available on [http://localhost:4000](http://localhost:4000).
+
 
 ---
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ server:
 
 database:
   driver: "mysql"
-  url: "root:@tcp(localhost:3306)/ozge_contract?parseTime=true"
+  url: "root:@tcp(db:3306)/ozge_contract?parseTime=true"
 
 mobizon:
   api_key: "kzfaad0a91a4b498db593b78414dfdaa2c213b8b8996afa325a223543481efeb11dd11"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: "3.9"
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: ozgecontract-db
+    restart: always
+    env_file:
+      - .env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - dbdata:/var/lib/mysql
+    networks:
+      - ozgecontractnet
+
+  migrate:
+    image: migrate/migrate
+    depends_on:
+      - db
+    volumes:
+      - ./migrations:/migrations
+    command: [
+      "-source", "file:///migrations",
+      "-database", "mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(db:3306)/${MYSQL_DATABASE}?parseTime=true",
+      "up"
+    ]
+    networks:
+      - ozgecontractnet
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: ozgecontract-backend
+    restart: always
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      DSN: ${DSN}
+      APP_PORT: ${APP_PORT}
+      DATABASE_URL: ${DATABASE_URL}
+    ports:
+      - "${APP_PORT}:4000"
+    command: ["./wait-for-mysql.sh", "./app"]
+    volumes:
+      - ./config:/app/config
+      - ./wait-for-mysql.sh:/app/wait-for-mysql.sh
+    networks:
+      - ozgecontractnet
+
+volumes:
+  dbdata:
+
+networks:
+  ozgecontractnet:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,8 +24,14 @@ type Config struct {
 func LoadConfig() Config {
 	var cfg Config
 
+	// Determine config file path
+	path := os.Getenv("CONFIG_PATH")
+	if path == "" {
+		path = "config/config.yaml"
+	}
+
 	// Read config file
-	data, err := os.ReadFile("C:\\Users\\alimz\\GolandProjects\\OzgeContract\\config\\config.yaml")
+	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("Failed to read config file: %v", err)
 	}
@@ -34,6 +40,11 @@ func LoadConfig() Config {
 	err = yaml.Unmarshal(data, &cfg)
 	if err != nil {
 		log.Fatalf("Failed to unmarshal config data: %v", err)
+	}
+
+	// Override database URL if provided via environment
+	if envURL := os.Getenv("DATABASE_URL"); envURL != "" {
+		cfg.Database.URL = envURL
 	}
 
 	return cfg

--- a/internal/handlers/contract_handler.go
+++ b/internal/handlers/contract_handler.go
@@ -47,7 +47,11 @@ func (h *ContractHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contractsDir := fmt.Sprintf("C:\\Users\\alimz\\GolandProjects\\OzgeContract\\uploads\\contracts\\company_%d", input.CompanyID)
+	baseDir := os.Getenv("DATA_DIR")
+	if baseDir == "" {
+		baseDir = "uploads"
+	}
+	contractsDir := filepath.Join(baseDir, "contracts", fmt.Sprintf("company_%d", input.CompanyID))
 	if err := os.MkdirAll(contractsDir, 0755); err != nil {
 		http.Error(w, "cannot create directory", http.StatusInternalServerError)
 		return
@@ -186,7 +190,11 @@ func (h *ContractHandler) CreateWithFields(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	contractsDir := fmt.Sprintf("uploads/contracts/company_%d", contract.CompanyID)
+	baseDir := os.Getenv("DATA_DIR")
+	if baseDir == "" {
+		baseDir = "uploads"
+	}
+	contractsDir := filepath.Join(baseDir, "contracts", fmt.Sprintf("company_%d", contract.CompanyID))
 	if err := os.MkdirAll(contractsDir, 0755); err != nil {
 		http.Error(w, "cannot create directory", http.StatusInternalServerError)
 		return

--- a/internal/handlers/signature_handler.go
+++ b/internal/handlers/signature_handler.go
@@ -64,7 +64,11 @@ func (h *SignatureHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signDir := fmt.Sprintf("C:\\Users\\alimz\\GolandProjects\\OzgeContract\\uploads\\signatures\\company_%d", contract.CompanyID)
+	baseDir := os.Getenv("DATA_DIR")
+	if baseDir == "" {
+		baseDir = "uploads"
+	}
+	signDir := filepath.Join(baseDir, "signatures", fmt.Sprintf("company_%d", contract.CompanyID))
 	if err := os.MkdirAll(signDir, 0755); err != nil {
 		http.Error(w, "cannot create directory", http.StatusInternalServerError)
 		return

--- a/internal/handlers/template_handler.go
+++ b/internal/handlers/template_handler.go
@@ -41,7 +41,11 @@ func (h *TemplateHandler) Upload(w http.ResponseWriter, r *http.Request) {
 	name := r.FormValue("name")
 
 	// --- Создаём директорию для компании
-	companyDir := fmt.Sprintf("C:\\Users\\alimz\\GolandProjects\\OzgeContract\\uploads\\templates\\company_%d", companyID)
+	baseDir := os.Getenv("DATA_DIR")
+	if baseDir == "" {
+		baseDir = "uploads"
+	}
+	companyDir := filepath.Join(baseDir, "templates", fmt.Sprintf("company_%d", companyID))
 	if err := os.MkdirAll(companyDir, 0755); err != nil {
 		http.Error(w, "cannot create directory", http.StatusInternalServerError)
 		return
@@ -67,7 +71,12 @@ func (h *TemplateHandler) Upload(w http.ResponseWriter, r *http.Request) {
 
 	// --- Watermark
 	desc := "op:0.2, pos:bottom-right, scale:0.1, rot:0, off:-20 20"
-	wm, err := pdfcpu.ParseImageWatermarkDetails("C:\\Users\\alimz\\GolandProjects\\OzgeContract\\static\\contract-logo.png", desc, false, types.POINTS)
+	staticDir := os.Getenv("STATIC_DIR")
+	if staticDir == "" {
+		staticDir = "static"
+	}
+	logoPath := filepath.Join(staticDir, "contract-logo.png")
+	wm, err := pdfcpu.ParseImageWatermarkDetails(logoPath, desc, false, types.POINTS)
 	if err != nil {
 		http.Error(w, "cannot parse image watermark: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/wait-for-mysql.sh
+++ b/wait-for-mysql.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+HOST="${DB_HOST:-db}"
+PORT="${DB_PORT:-3306}"
+
+while ! nc -z "$HOST" "$PORT" >/dev/null 2>&1; do
+  echo "Waiting for MySQL at $HOST:$PORT..."
+  sleep 1
+done
+
+exec "$@"


### PR DESCRIPTION
## Summary
- remove previous migration entrypoint
- add wait-for-mysql helper
- provide `.env` example
- update Dockerfile and docker-compose.yml using ozgecontract
- document compose usage in README

## Testing
- `gofmt -w internal/config/config.go internal/handlers/contract_handler.go internal/handlers/template_handler.go internal/handlers/signature_handler.go`
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_6857b69710588324a1a95cd5c718f16b