### PR TITLE
Add QR-specific update endpoint

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -44,6 +44,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/signatures/contract/:id", standardMiddleware.ThenFunc(app.signatureHandler.GetByContractID))
 	mux.Get("/signatures/company/:id", standardMiddleware.ThenFunc(app.signatureHandler.GetContractsByCompanyID))
 	mux.Get("/signatures/admin/all", standardMiddleware.ThenFunc(app.signatureHandler.GetSignaturesAll))
+	mux.Put("/signatures/qr/:id", standardMiddleware.ThenFunc(app.signatureHandler.UpdateQR))
 	mux.Del("/signatures/:id", standardMiddleware.ThenFunc(app.signatureHandler.Delete))
 	mux.Post("/signatures/sign", standardMiddleware.ThenFunc(app.signatureHandler.Sign))
 	mux.Get("/signatures/pdf/:id", standardMiddleware.ThenFunc(app.signatureHandler.ServeSignedPDFByID))


### PR DESCRIPTION
## Summary
- make signature creation respond with the new ID
- add `/signatures/qr/:id` route for uploading QR-signed files
- remove the generic update handler and its route

## Testing
- `go test ./...` *(fails: modules cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68587983060c8324b94ba7339ae30ffd