### PR TITLE
Add status summary endpoint

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -44,6 +44,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/signatures/contract/:id", standardMiddleware.ThenFunc(app.signatureHandler.GetByContractID))
 	mux.Get("/signatures/company/:id", standardMiddleware.ThenFunc(app.signatureHandler.GetContractsByCompanyID))
 	mux.Get("/signatures/admin/all", standardMiddleware.ThenFunc(app.signatureHandler.GetSignaturesAll))
+	mux.Get("/signatures/status-summary", standardMiddleware.ThenFunc(app.signatureHandler.GetStatusSummary))
 	mux.Put("/signatures/qr/:id", standardMiddleware.ThenFunc(app.signatureHandler.UpdateQR))
 	mux.Del("/signatures/:id", standardMiddleware.ThenFunc(app.signatureHandler.Delete))
 	mux.Post("/signatures/sign", standardMiddleware.ThenFunc(app.signatureHandler.Sign))

--- a/internal/handlers/signature_handler.go
+++ b/internal/handlers/signature_handler.go
@@ -334,3 +334,13 @@ func (h *SignatureHandler) ServeSignedPDFByID(w http.ResponseWriter, r *http.Req
 	w.Header().Set("Content-Disposition", "inline; filename=\""+filepath.Base(filePath)+"\"")
 	http.ServeFile(w, r, filePath)
 }
+
+func (h *SignatureHandler) GetStatusSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := h.Service.GetStatusSummary()
+	if err != nil {
+		http.Error(w, "cannot get summary", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(summary)
+}

--- a/internal/models/signature_status_summary.go
+++ b/internal/models/signature_status_summary.go
@@ -1,0 +1,9 @@
+package models
+
+// SignatureStatusSummary represents counts of signatures by status.
+type SignatureStatusSummary struct {
+	Total    int `json:"total"`
+	Signed   int `json:"signed"`
+	Pending  int `json:"pending"`
+	Declined int `json:"declined"`
+}

--- a/internal/repositories/signature_repo.go
+++ b/internal/repositories/signature_repo.go
@@ -242,3 +242,18 @@ func (r *SignatureRepository) UpdateSignFilePath(signatureID int, path string) e
 	_, err := r.DB.Exec("UPDATE signatures SET sign_file_path = ? WHERE id = ?", path, signatureID)
 	return err
 }
+
+func (r *SignatureRepository) GetStatusSummary() (*models.SignatureStatusSummary, error) {
+	summary := &models.SignatureStatusSummary{}
+	query := `SELECT 
+                COUNT(id) AS total,
+                SUM(CASE WHEN status = 1 THEN 1 ELSE 0 END) AS signed,
+                SUM(CASE WHEN status = 0 THEN 1 ELSE 0 END) AS pending,
+                SUM(CASE WHEN status = 3 THEN 1 ELSE 0 END) AS declined
+        FROM signatures`
+	row := r.DB.QueryRow(query)
+	if err := row.Scan(&summary.Total, &summary.Signed, &summary.Pending, &summary.Declined); err != nil {
+		return nil, err
+	}
+	return summary, nil
+}

--- a/internal/services/signature_service.go
+++ b/internal/services/signature_service.go
@@ -68,3 +68,7 @@ func (s *SignatureService) Sign(contractID int, clientName, clientIIN, clientPho
 
 	return s.Repo.Create(signature)
 }
+
+func (s *SignatureService) GetStatusSummary() (*models.SignatureStatusSummary, error) {
+	return s.Repo.GetStatusSummary()
+}


### PR DESCRIPTION
## Summary
- create `SignatureStatusSummary` model for aggregated counts
- add repository method to gather signature statuses
- add service and handler for new `/signatures/status-summary` endpoint
- wire route to new handler

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858e6b562e883248abedcefc1d5d0a4