### PR TITLE
Add company balance existence check on update

### DIFF
--- a/internal/services/company_balance_service.go
+++ b/internal/services/company_balance_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"OzgeContract/internal/models"
 	"OzgeContract/internal/repositories"
+	"database/sql"
 )
 
 type CompanyBalanceService struct {
@@ -22,6 +23,13 @@ func (s *CompanyBalanceService) GetByCompanyID(companyID int) (*models.CompanyBa
 }
 
 func (s *CompanyBalanceService) Update(cb *models.CompanyBalance) error {
+	_, err := s.Repo.GetByCompanyID(cb.CompanyID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return s.Repo.Create(cb)
+		}
+		return err
+	}
 	return s.Repo.Update(cb)
 }
 


### PR DESCRIPTION
## Summary
- add existence check before updating company balance to insert when no record exists

## Testing
- `go vet ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858ff0ecac88324ba61d137f27b5769