### PR TITLE
Implement default company balance and adjust payment request ordering

### DIFF
--- a/cmd/web/initializer.go
+++ b/cmd/web/initializer.go
@@ -32,8 +32,9 @@ type application struct {
 func initializeApp(cfg config.Config, db *sql.DB, errorLog, infoLog *log.Logger) *application {
 
 	// Company
+	companyBalanceRepo := repository.NewCompanyBalanceRepository(db)
 	companyRepo := repository.NewCompanyRepository(db)
-	companyService := service.NewCompanyService(companyRepo)
+	companyService := service.NewCompanyService(companyRepo, companyBalanceRepo)
 	companyHandler := handlers.NewCompanyHandler(companyService)
 
 	// Template
@@ -63,7 +64,6 @@ func initializeApp(cfg config.Config, db *sql.DB, errorLog, infoLog *log.Logger)
 	statsService := service.NewStatisticsService(statsRepo)
 	statsHandler := handlers.NewStatisticsHandler(statsService)
 
-	companyBalanceRepo := repository.NewCompanyBalanceRepository(db)
 	companyBalanceService := service.NewCompanyBalanceService(companyBalanceRepo)
 	companyBalanceHandler := handlers.NewCompanyBalanceHandler(companyBalanceService)
 


### PR DESCRIPTION
## Summary
- create default company balance on company registration
- update initializer to provide balance repo to company service
- prioritize pending payment requests in admin list view

## Testing
- `go vet ./...` *(fails: proxy.golang.org forbidden)*
- `go build ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a74c866748324bfeee8681b23efd7