### PR TITLE
Balance deduction on signature creation

### DIFF
--- a/cmd/web/initializer.go
+++ b/cmd/web/initializer.go
@@ -50,7 +50,7 @@ func initializeApp(cfg config.Config, db *sql.DB, errorLog, infoLog *log.Logger)
 
 	// Signatures
 	signatureRepo := repository.NewSignatureRepository(db)
-	signatureService := service.NewSignatureService(signatureRepo, contractRepo)
+	signatureService := service.NewSignatureService(signatureRepo, contractRepo, companyBalanceRepo)
 	signatureFieldValueRepo := repository.NewSignatureFieldValueRepository(db)
 	signatureFieldValueService := service.NewSignatureFieldValueService(signatureFieldValueRepo)
 	signatureHandler := handlers.NewSignatureHandler(signatureService, signatureFieldValueService)


### PR DESCRIPTION
## Summary
- wire company balance repository into signature service
- deduct the appropriate signature balance when `/signatures` POST succeeds

## Testing
- `go vet ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bc6be80dc832495f00e82286384d1