### PR TITLE
Add change password endpoint

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -21,6 +21,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/companies/phone/:phone", standardMiddleware.ThenFunc(app.companyHandler.GetByPhone))
 	mux.Put("/companies/:id", standardMiddleware.ThenFunc(app.companyHandler.Update))
 	mux.Del("/companies/:id", standardMiddleware.ThenFunc(app.companyHandler.Delete))
+	mux.Post("/companies/:id/change-password", standardMiddleware.ThenFunc(app.companyHandler.ChangePassword))
 
 	mux.Post("/templates/upload", standardMiddleware.ThenFunc(app.templateHandler.Upload))
 	mux.Get("/templates/:id", standardMiddleware.ThenFunc(app.templateHandler.GetByID))

--- a/internal/handlers/company_handler.go
+++ b/internal/handlers/company_handler.go
@@ -199,3 +199,27 @@ func (h *CompanyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 }
+
+func (h *CompanyHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid company ID", http.StatusBadRequest)
+		return
+	}
+
+	var input struct {
+		OldPassword string `json:"old_password"`
+		NewPassword string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil || input.OldPassword == "" || input.NewPassword == "" {
+		http.Error(w, "invalid input", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.Service.ChangePassword(id, input.OldPassword, input.NewPassword); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/repositories/company_repo.go
+++ b/internal/repositories/company_repo.go
@@ -267,3 +267,19 @@ func (r *CompanyRepository) Delete(id int) error {
 	_, err := r.DB.Exec(`DELETE FROM companies WHERE id = ?`, id)
 	return err
 }
+
+func (r *CompanyRepository) UpdatePassword(id int, oldPassword, newPassword string) error {
+	var hashed string
+	if err := r.DB.QueryRow("SELECT password FROM companies WHERE id = ?", id).Scan(&hashed); err != nil {
+		return err
+	}
+	if bcrypt.CompareHashAndPassword([]byte(hashed), []byte(oldPassword)) != nil {
+		return errors.New("invalid password")
+	}
+	newHashed, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
+	if err != nil {
+		return err
+	}
+	_, err = r.DB.Exec("UPDATE companies SET password=? WHERE id=?", newHashed, id)
+	return err
+}

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -60,3 +60,7 @@ func (s *CompanyService) Update(c *models.Company) error {
 func (s *CompanyService) Delete(id int) error {
 	return s.Repo.Delete(id)
 }
+
+func (s *CompanyService) ChangePassword(id int, oldPassword, newPassword string) error {
+	return s.Repo.UpdatePassword(id, oldPassword, newPassword)
+}


### PR DESCRIPTION
## Summary
- implement password change logic in company repository and service
- expose handler and route for `/companies/:id/change-password`

## Testing
- `go test ./...` *(fails: access to proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bd4c1162883248e4af9ae44a0bec8