### PR TITLE
Implement password reset endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ clean_mobile_app/
 * `GET /contracts/token/{token}/details` – retrieve a contract by token along with its signing method, `company_sign` status and list of additional fields.
 * `POST /signatures` – create a signature for a contract. Along with standard fields you can pass a `field_values` JSON array to store values for the contract's additional fields in one request.
 
+## Company API
+
+* `POST /companies/{id}/reset-password` – generate a new password for a company without providing the old one.
+
 ---
 
 ## 🛠️ Installation

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -22,6 +22,7 @@ func (app *application) routes() http.Handler {
 	mux.Put("/companies/:id", standardMiddleware.ThenFunc(app.companyHandler.Update))
 	mux.Del("/companies/:id", standardMiddleware.ThenFunc(app.companyHandler.Delete))
 	mux.Post("/companies/:id/change-password", standardMiddleware.ThenFunc(app.companyHandler.ChangePassword))
+	mux.Post("/companies/:id/reset-password", standardMiddleware.ThenFunc(app.companyHandler.ResetPassword))
 
 	mux.Post("/templates/upload", standardMiddleware.ThenFunc(app.templateHandler.Upload))
 	mux.Get("/templates/:id", standardMiddleware.ThenFunc(app.templateHandler.GetByID))

--- a/internal/handlers/company_handler.go
+++ b/internal/handlers/company_handler.go
@@ -223,3 +223,21 @@ func (h *CompanyHandler) ChangePassword(w http.ResponseWriter, r *http.Request) 
 	}
 	w.WriteHeader(http.StatusOK)
 }
+
+func (h *CompanyHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid company ID", http.StatusBadRequest)
+		return
+	}
+
+	newPassword, err := h.Service.ResetPassword(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"new_password": newPassword})
+}

--- a/internal/repositories/company_repo.go
+++ b/internal/repositories/company_repo.go
@@ -283,3 +283,12 @@ func (r *CompanyRepository) UpdatePassword(id int, oldPassword, newPassword stri
 	_, err = r.DB.Exec("UPDATE companies SET password=? WHERE id=?", newHashed, id)
 	return err
 }
+
+func (r *CompanyRepository) ResetPassword(id int, newPassword string) error {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
+	if err != nil {
+		return err
+	}
+	_, err = r.DB.Exec("UPDATE companies SET password=? WHERE id=?", hashed, id)
+	return err
+}

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -3,6 +3,8 @@ package services
 import (
 	"OzgeContract/internal/models"
 	"OzgeContract/internal/repositories"
+	"math/rand"
+	"time"
 )
 
 type CompanyService struct {
@@ -63,4 +65,22 @@ func (s *CompanyService) Delete(id int) error {
 
 func (s *CompanyService) ChangePassword(id int, oldPassword, newPassword string) error {
 	return s.Repo.UpdatePassword(id, oldPassword, newPassword)
+}
+
+func generatePassword(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, n)
+	rand.Seed(time.Now().UnixNano())
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func (s *CompanyService) ResetPassword(id int) (string, error) {
+	newPassword := generatePassword(8)
+	if err := s.Repo.ResetPassword(id, newPassword); err != nil {
+		return "", err
+	}
+	return newPassword, nil
 }


### PR DESCRIPTION
## Summary
- add `ResetPassword` method to company repository/service/handler
- create `POST /companies/:id/reset-password` route
- document endpoint in README

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cfc9dc08c8324ad8d2b16c78410ae