### PR TITLE
Update reset password endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ clean_mobile_app/
 * `GET /contracts/token/{token}/details` – retrieve a contract by token along with its signing method, `company_sign` status and list of additional fields.
 * `POST /signatures` – create a signature for a contract. Along with standard fields you can pass a `field_values` JSON array to store values for the contract's additional fields in one request.
 
+## Company API
+
+* `POST /companies/{id}/reset-password` – set a new password for a company without providing the old one. The request body is `{ "new_password": "..." }`.
+
 ---
 
 ## 🛠️ Installation

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -22,6 +22,7 @@ func (app *application) routes() http.Handler {
 	mux.Put("/companies/:id", standardMiddleware.ThenFunc(app.companyHandler.Update))
 	mux.Del("/companies/:id", standardMiddleware.ThenFunc(app.companyHandler.Delete))
 	mux.Post("/companies/:id/change-password", standardMiddleware.ThenFunc(app.companyHandler.ChangePassword))
+	mux.Post("/companies/:id/reset-password", standardMiddleware.ThenFunc(app.companyHandler.ResetPassword))
 
 	mux.Post("/templates/upload", standardMiddleware.ThenFunc(app.templateHandler.Upload))
 	mux.Get("/templates/:id", standardMiddleware.ThenFunc(app.templateHandler.GetByID))

--- a/internal/handlers/company_handler.go
+++ b/internal/handlers/company_handler.go
@@ -223,3 +223,27 @@ func (h *CompanyHandler) ChangePassword(w http.ResponseWriter, r *http.Request) 
 	}
 	w.WriteHeader(http.StatusOK)
 }
+
+func (h *CompanyHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid company ID", http.StatusBadRequest)
+		return
+	}
+
+	var input struct {
+		NewPassword string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil || input.NewPassword == "" {
+		http.Error(w, "invalid input", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.Service.ResetPassword(id, input.NewPassword); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/repositories/company_repo.go
+++ b/internal/repositories/company_repo.go
@@ -283,3 +283,12 @@ func (r *CompanyRepository) UpdatePassword(id int, oldPassword, newPassword stri
 	_, err = r.DB.Exec("UPDATE companies SET password=? WHERE id=?", newHashed, id)
 	return err
 }
+
+func (r *CompanyRepository) ResetPassword(id int, newPassword string) error {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
+	if err != nil {
+		return err
+	}
+	_, err = r.DB.Exec("UPDATE companies SET password=? WHERE id=?", hashed, id)
+	return err
+}

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -64,3 +64,7 @@ func (s *CompanyService) Delete(id int) error {
 func (s *CompanyService) ChangePassword(id int, oldPassword, newPassword string) error {
 	return s.Repo.UpdatePassword(id, oldPassword, newPassword)
 }
+
+func (s *CompanyService) ResetPassword(id int, newPassword string) error {
+	return s.Repo.ResetPassword(id, newPassword)
+}


### PR DESCRIPTION
## Summary
- change `ResetPassword` to accept a new password from the client
- update handler logic to read `new_password` from the request body
- document new reset-password behavior

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cfc9dc08c8324ad8d2b16c78410ae