### PR TITLE
Adjust company stats to count unique clients

### DIFF
--- a/internal/models/statistics.go
+++ b/internal/models/statistics.go
@@ -9,9 +9,9 @@ type LastSignedContract struct {
 }
 
 type CompanyStats struct {
-	CompanyID       int                  `json:"company_id"`
-	TotalSigned     int                  `json:"total_signed"`
-	ActiveContracts int                  `json:"active_contracts"`
-	SignedThisMonth int                  `json:"signed_this_month"`
-	LastSigned      []LastSignedContract `json:"last_signed_contracts"`
+	CompanyID        int                  `json:"company_id"`
+	TotalSigned      int                  `json:"total_signed"`
+	UniqueSignatures int                  `json:"unique_signatures"`
+	SignedThisMonth  int                  `json:"signed_this_month"`
+	LastSigned       []LastSignedContract `json:"last_signed_contracts"`
 }

--- a/internal/repositories/statistics_repo.go
+++ b/internal/repositories/statistics_repo.go
@@ -26,12 +26,12 @@ func (r *StatisticsRepository) GetCompanyStats(companyID int) (*models.CompanySt
 		return nil, err
 	}
 
-	// 2. Активные контракты (без подписей)
+	// 2. Уникальные подписи по client_iin
 	err = r.DB.QueryRow(`
-		SELECT COUNT(c.id)
-		FROM contracts c
-		LEFT JOIN signatures s ON s.contract_id = c.id
-		WHERE c.company_id = ? AND s.id IS NULL`, companyID).Scan(&stats.ActiveContracts)
+               SELECT COUNT(DISTINCT s.client_iin)
+               FROM signatures s
+               JOIN contracts c ON s.contract_id = c.id
+               WHERE c.company_id = ?`, companyID).Scan(&stats.UniqueSignatures)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- change `CompanyStats` field `ActiveContracts` to `UniqueSignatures`
- count unique signatures by `client_iin` in statistics repo

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d090832408324a60d740a9832e2ee