### PR TITLE
Add dashboard summary route with aggregated stats

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -59,6 +59,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/signature-fields/signature/:id", standardMiddleware.ThenFunc(app.signatureFieldValueHandler.GetBySignatureID))
 
 	mux.Get("/stats/company/:id", standardMiddleware.ThenFunc(app.statisticsHandler.GetCompanyStats))
+	mux.Get("/dashboard/summary", standardMiddleware.ThenFunc(app.statisticsHandler.GetDashboardSummary))
 
 	mux.Post("/company-balances", standardMiddleware.ThenFunc(app.companyBalanceHandler.Create))
 	mux.Get("/company-balances/:id", standardMiddleware.ThenFunc(app.companyBalanceHandler.GetByCompanyID))

--- a/internal/handlers/statistics_handler.go
+++ b/internal/handlers/statistics_handler.go
@@ -27,3 +27,14 @@ func (h *StatisticsHandler) GetCompanyStats(w http.ResponseWriter, r *http.Reque
 	}
 	json.NewEncoder(w).Encode(stats)
 }
+
+// GetDashboardSummary handles GET /dashboard/summary and returns aggregated
+// statistics in JSON format.
+func (h *StatisticsHandler) GetDashboardSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := h.Service.GetDashboardSummary()
+	if err != nil {
+		http.Error(w, "cannot get dashboard summary", http.StatusInternalServerError)
+		return
+	}
+	w.Write(summary)
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -16,3 +16,8 @@ func NewStatisticsService(repo *repositories.StatisticsRepository) *StatisticsSe
 func (s *StatisticsService) GetCompanyStats(companyID int) (*models.CompanyStats, error) {
 	return s.Repo.GetCompanyStats(companyID)
 }
+
+// GetDashboardSummary retrieves aggregated dashboard statistics.
+func (s *StatisticsService) GetDashboardSummary() ([]byte, error) {
+	return s.Repo.GetDashboardSummary()
+}


### PR DESCRIPTION
## Summary
- add /dashboard/summary route to expose aggregated dashboard statistics
- compute stats with single SQL query using CTEs and return JSON payload
- fix CTE correlations so parameters are referenced properly

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7adc4344c83249f44ad6da614daae